### PR TITLE
update SOLR from 4.10.2 to 4.10.4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Depends: postgresql, apache2-mpm-worker, libapache2-mod-wsgi, python-pip, gettex
     unifiedviews-pgsql (>= 2.3), unifiedviews-pgsql (<< 2.4),
     odn-midpoint (>= 1:3.3.1-odn1.6.0), odn-midpoint (<< 1:3.4-odn1.7),
     odn-cas (>= 1.1), odn-cas (<< 1.2),
-    odn-solr (>= 4.10.2-odn1.0), odn-solr (<< 4.10.2-odn1.2),
+    odn-solr (>= 4.10.2-odn1.1.0), odn-solr (<< 5.0.0-odn1.2.0),
     odn-ckan-shared (>= 2.3.2-odn1.6), odn-ckan-shared (<< 2.4.0-odn1.7),
     odn-uv-plugins (>= 1.4), odn-uv-plugins (<< 1.5),
     virtuoso-opensource (>= 7.2), virtuoso-opensource (<< 7.3)


### PR DESCRIPTION
This PR bumps up odn-solr version to match https://github.com/OpenDataNode/odn-solr/pull/1 .